### PR TITLE
lualine for status and tabline

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -1,4 +1,6 @@
 {
   "lazy.nvim": { "branch": "main", "commit": "f15a93907ddad3d9139aea465ae18336d87f5ce6" },
+  "lualine.nvim": { "branch": "master", "commit": "f4f791f67e70d378a754d02da068231d2352e5bc" },
+  "nvim-web-devicons": { "branch": "master", "commit": "402377242b04be3f4f0f3720bd952df86e946c30" },
   "oil.nvim": { "branch": "master", "commit": "add50252b5e9147c0a09d36480d418c7e2737472" }
 }

--- a/lua/config/lualine.lua
+++ b/lua/config/lualine.lua
@@ -1,0 +1,50 @@
+local M = {}
+
+function M.setup()
+  require('lualine').setup({
+    options = {
+      theme = 'auto',
+      component_separators = { left = '|', right = '|'},
+      section_separators = { left = '', right = ''},
+      disabled_filetypes = {
+        statusline = {},
+        winbar = {},
+      },
+      ignore_focus = {},
+      always_divide_middle = true,
+      globalstatus = true,
+      refresh = {
+        statusline = 1000,
+        tabline = 1000,
+        winbar = 1000,
+      }
+    },
+    sections = {
+      lualine_a = {'mode'},
+      lualine_b = {'filename'},
+      lualine_c = {'diagnostics'},
+      lualine_x = {'encoding', 'fileformat', 'filetype'},
+      lualine_y = {'progress'},
+      lualine_z = {'location'}
+    },
+    inactive_sections = {
+      lualine_a = {},
+      lualine_b = {},
+      lualine_c = {'filename'},
+      lualine_x = {'location'},
+      lualine_y = {},
+      lualine_z = {}
+    },
+    tabline = {
+      lualine_a = {'buffers'},
+      lualine_b = {},
+      lualine_c = {},
+      lualine_x = {},
+      lualine_y = {},
+      lualine_z = {'tabs'}
+    },
+    extensions = {'neo-tree', 'oil', 'toggleterm', 'nvim-dap-ui'}
+  })
+end
+
+return M

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -1,0 +1,9 @@
+return {
+  {
+    "nvim-lualine/lualine.nvim",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    config = function()
+      require("config.lualine").setup()
+    end,
+  },
+}


### PR DESCRIPTION
This pull request includes the addition of the `lualine.nvim` plugin configuration and its dependencies. The most important changes include updating the `lazy-lock.json` file, adding a configuration file for `lualine`, and setting up the plugin in the `plugins` directory.

### Plugin Configuration:

* [`lua/config/lualine.lua`](diffhunk://#diff-f2acbddc102b6a49662abd052fb44a7ad4e36bd612003fc2310d99232fa9d673R1-R50): Added a new configuration file for `lualine.nvim`, defining its setup with various options, sections, inactive sections, tabline, and extensions.

### Plugin Setup:

* [`lua/plugins/lualine.lua`](diffhunk://#diff-82426f6abab684cdbcde6cbe04db34ed5297ce46908a40c154be0a54ae113377R1-R9): Added the `lualine.nvim` plugin and its dependency on `nvim-web-devicons`, and configured it to use the setup defined in `config.lualine`.

### Dependency Update:

* [`lazy-lock.json`](diffhunk://#diff-38c3069a80837a83b8298c8f4f35d135960a5fb36eaa5bd33e1c71cae4b86379R3-R4): Updated to include the `lualine.nvim` and `nvim-web-devicons` plugins with their respective commits.