### PR TITLE
telescope

### DIFF
--- a/lua/config/telescope.lua
+++ b/lua/config/telescope.lua
@@ -1,0 +1,69 @@
+local M = {}
+
+function M.setup()
+  local telescope = require("telescope")
+  local actions = require("telescope.actions")
+
+  telescope.setup({
+    defaults = {
+      prompt_prefix = "🔍 ",
+      selection_caret = " ",
+      -- path_display = { "smart" },
+      path_display = { "truncate" },
+      mappings = {
+        i = {
+          ["<C-j>"] = actions.move_selection_next,
+          ["<C-k>"] = actions.move_selection_previous,
+          ["<C-q>"] = actions.send_to_qflist + actions.open_qflist,
+        },
+      },
+      layout_strategy = "horizontal",
+      layout_config = {
+        horizontal = {
+          prompt_position = "top",
+          preview_width = 0.55,
+          results_width = 0.8,
+        },
+        vertical = {
+          mirror = false,
+        },
+        width = 0.87,
+        height = 0.80,
+        preview_cutoff = 120,
+      },
+      file_ignore_patterns = {
+        "node_modules",
+        ".git",
+        ".cache",
+        "%.o",
+        "%.a",
+        "%.out",
+        "%.class",
+        "%.pdf",
+        "%.mkv",
+        "%.mp4",
+        "%.zip",
+      },
+      winblend = 0,
+      border = {},
+      color_devicons = true,
+      set_env = { ["COLORTERM"] = "truecolor" },
+    },
+    extensions = {
+      file_browser = {
+        theme = "dropdown",
+        hijack_netrw = true,
+        hidden = true,
+      },
+      ["ui-select"] = {
+        require("telescope.themes").get_dropdown(),
+      },
+    },
+  })
+
+  -- Load extensions
+  telescope.load_extension("file_browser")
+  telescope.load_extension("ui-select")
+end
+
+return M

--- a/lua/config/telescope_keymaps.lua
+++ b/lua/config/telescope_keymaps.lua
@@ -1,0 +1,32 @@
+local M = {}
+
+function M.setup()
+  local builtin = require("telescope.builtin")
+  local extensions = require("telescope").extensions
+
+  -- File operations
+  vim.keymap.set("n", "<leader>ff", builtin.find_files, { desc = "Find Files" })
+  vim.keymap.set("n", "<leader>fg", builtin.live_grep, { desc = "Live Grep" })
+  vim.keymap.set("n", "<leader>fb", builtin.buffers, { desc = "Find Buffers" })
+  vim.keymap.set("n", "<leader>fh", builtin.help_tags, { desc = "Help Tags" })
+  vim.keymap.set("n", "<leader>fr", builtin.oldfiles, { desc = "Recent Files" })
+
+  -- Git integration
+  vim.keymap.set("n", "<leader>gc", builtin.git_commits, { desc = "Git Commits" })
+  vim.keymap.set("n", "<leader>gs", builtin.git_status, { desc = "Git Status" })
+
+  -- Code navigation
+  vim.keymap.set("n", "<leader>cd", builtin.lsp_definitions, { desc = "Goto Definition" })
+  vim.keymap.set("n", "<leader>cr", builtin.lsp_references, { desc = "References" })
+  vim.keymap.set("n", "<leader>cs", builtin.lsp_document_symbols, { desc = "Document Symbols" })
+
+  -- File browser
+  vim.keymap.set("n", "<leader>fe", extensions.file_browser.file_browser, { desc = "File Browser" })
+
+  -- Custom searches
+  vim.keymap.set("n", "<leader>fw", function()
+    builtin.grep_string({ search = vim.fn.input("Grep > ") })
+  end, { desc = "Grep Word" })
+end
+
+return M

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -1,0 +1,14 @@
+return {
+  {
+    "nvim-telescope/telescope.nvim",
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      "nvim-telescope/telescope-file-browser.nvim",
+      "nvim-telescope/telescope-ui-select.nvim",
+    },
+    config = function()
+      require("config.telescope").setup()
+      require("config.telescope_keymaps").setup()
+    end,
+  },
+}


### PR DESCRIPTION
This pull request introduces a new configuration for the Telescope plugin in Neovim. It includes setting up Telescope with custom settings, defining key mappings for various Telescope functions, and adding necessary dependencies.

### Telescope Configuration:

* [`lua/config/telescope.lua`](diffhunk://#diff-a809fccb3fa108c747954bf4149e6135f8df3ad9431f3d2373e7c5f7e737507dR1-R69): Added a new module to configure Telescope with custom settings, such as prompt prefix, selection caret, layout strategy, file ignore patterns, and extensions for file browser and UI select.

### Key Mappings:

* [`lua/config/telescope_keymaps.lua`](diffhunk://#diff-1c858c9ae5bc3ace0ec7cc77b62d87a21968c16229e944b6700d95bb74ce06a1R1-R32): Added a new module to define key mappings for Telescope functions, including file operations, Git integration, code navigation, file browser, and custom searches.

### Plugin Dependencies:

* [`lua/plugins/telescope.lua`](diffhunk://#diff-59e87d2a9ea2b03f480ea0a824e57e1235a65843e4477b2f3da8d78524e1139cR1-R14): Added the Telescope plugin along with its dependencies (`plenary.nvim`, `telescope-file-browser.nvim`, and `telescope-ui-select.nvim`). Configured the plugin to use the new setup and key mappings.