### PR TITLE
Add key mappings documentation

### DIFF
--- a/KEYS.md
+++ b/KEYS.md
@@ -1,0 +1,33 @@
+# Key Mappings
+
+## Noice Key Mappings
+- `<leader>nl`: Noice Last Message
+- `<leader>nh`: Noice History
+- `<leader>na`: Noice All
+- `<leader>nd`: Dismiss All Notifications
+
+## Oil Key Mappings
+- `<leader>o`: Toggle Oil File Explorer
+
+## Telescope Key Mappings
+### File Operations
+- `<leader>ff`: Find Files
+- `<leader>fg`: Live Grep
+- `<leader>fb`: Find Buffers
+- `<leader>fh`: Help Tags
+- `<leader>fr`: Recent Files
+
+### Git Integration
+- `<leader>gc`: Git Commits
+- `<leader>gs`: Git Status
+
+### Code Navigation
+- `<leader>cd`: Goto Definition
+- `<leader>cr`: References
+- `<leader>cs`: Document Symbols
+
+### File Browser
+- `<leader>fe`: File Browser
+
+### Custom Searches
+- `<leader>fw`: Grep Word

--- a/README.md
+++ b/README.md
@@ -18,3 +18,6 @@ Open Neovim and start using the configured setup. You can customize the configur
 
 ## Contributing
 Contributions are welcome! Feel free to open issues or submit pull requests.
+
+## Key Mappings
+The available key mappings are documented in the `KEYS.md` file. Please refer to it for detailed information about the key mappings.


### PR DESCRIPTION
Fixes #9

Add documentation for available key mappings.

* **README.md**
  - Add a new section "Key Mappings" to document the available key mappings.
  - Include a reference to the new `KEYS.md` file in the "Key Mappings" section.

* **KEYS.md**
  - Create a new file to document the available key mappings.
  - Include key mappings from `lua/config/noice_keymaps.lua`.
  - Include key mappings from `lua/config/oil.lua`.
  - Include key mappings from `lua/config/telescope_keymaps.lua`.

