### PR TITLE
Update documentation for new plugins and key mappings

### DIFF
--- a/KEYS.md
+++ b/KEYS.md
@@ -31,3 +31,32 @@
 
 ### Custom Searches
 - `<leader>fw`: Grep Word
+
+## Alpha Key Mappings
+- `<leader>d`: Open Dashboard
+
+## CMP Key Mappings
+- `<C-Space>`: Trigger completion
+- `<CR>`: Confirm selection
+- `<Tab>`: Select next item or expand snippet
+- `<S-Tab>`: Select previous item or jump to previous snippet
+
+## LSP Key Mappings
+- `gd`: Go to definition
+- `K`: Hover documentation
+- `gr`: List references
+- `<leader>rn`: Rename symbol
+- `<leader>ca`: Code actions
+- `<leader>e`: Show diagnostics
+- `[d`: Go to previous diagnostic
+- `]d`: Go to next diagnostic
+- `<leader>co`: Organize imports (TypeScript)
+- `<leader>cr`: Remove unused imports (TypeScript)
+- `<leader>ci`: Add missing imports (TypeScript)
+- `<leader>cf`: Fix all issues (TypeScript)
+
+## Formatting Key Mappings
+- `<leader>fp`: Format file
+
+## Linting Key Mappings
+- `<leader>ll`: Trigger linting

--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ Contributions are welcome! Feel free to open issues or submit pull requests.
 
 ## Key Mappings
 The available key mappings are documented in the `KEYS.md` file. Please refer to it for detailed information about the key mappings.
+
+## New Plugins
+This configuration includes the following new plugins:
+- `noice.nvim`: Enhanced notifications and messages.
+- `oil.nvim`: File explorer with a floating window.
+- `telescope.nvim`: Fuzzy finder and more.


### PR DESCRIPTION
Fixes #13

Update `KEYS.md` and `README.md` files.

* **KEYS.md**:
  - Add key mappings for Alpha, CMP, LSP, Formatting, and Linting.
  - Include descriptions for new key mappings.

* **README.md**:
  - Add a section for new plugins including `noice.nvim`, `oil.nvim`, and `telescope.nvim`.
  - Update key mappings section to refer to `KEYS.md` for detailed information.

