### PR TITLE
Document all features and key maps

### DIFF
--- a/KEYS.md
+++ b/KEYS.md
@@ -60,3 +60,28 @@
 
 ## Linting Key Mappings
 - `<leader>ll`: Trigger linting
+
+## Bufferline Key Mappings
+- `<leader>bp`: Toggle pin
+- `<leader>bP`: Delete non-pinned
+- `<leader>bo`: Delete others
+- `<leader>br`: Delete to the right
+- `<leader>bl`: Delete to the left
+- `<Tab>`: Next tab
+- `<S-Tab>`: Previous tab
+- `<leader>bd`: Delete buffer
+
+## Multicursor Key Mappings
+- `<leader>n`: Match add cursor forward
+- `<leader>s`: Match skip cursor forward
+- `<leader>N`: Match add cursor backward
+- `<leader>S`: Match skip cursor backward
+- `<leader>A`: Add cursors for all matches
+- `<left>`: Next cursor
+- `<right>`: Previous cursor
+- `<leader>x`: Delete current cursor
+- `<C-q>`: Toggle cursors
+
+## Theming Key Mappings
+- `<leader>tt`: Cycle Themes
+- `<leader>th`: Preview Themes

--- a/KEYS.md
+++ b/KEYS.md
@@ -27,7 +27,7 @@
 - `<leader>cs`: Document Symbols
 
 ### File Browser
-- `<C-c>`: File Browser
+- `<C-e>`: File Browser
 
 ### Custom Searches
 - `<leader>fw`: Grep Word

--- a/KEYS.md
+++ b/KEYS.md
@@ -27,7 +27,7 @@
 - `<leader>cs`: Document Symbols
 
 ### File Browser
-- `<leader>fe`: File Browser
+- `<C-c>`: File Browser
 
 ### Custom Searches
 - `<leader>fw`: Grep Word

--- a/README.md
+++ b/README.md
@@ -26,3 +26,6 @@ The available key mappings are documented in the `KEYS.md` file. Please refer to
 - Enhanced notifications and messages using `noice.nvim`.
 - File explorer with a floating window using `oil.nvim`.
 - Fuzzy finder and more using `telescope.nvim`.
+- Bufferline management with `bufferline.nvim`.
+- Multicursor support with `multicursor.nvim`.
+- Theme switching with `theming.nvim`.


### PR DESCRIPTION
Fixes #20

Add documentation for all features and key maps.

* **KEYS.md**
  - Add key mappings for `bufferline` from `lua/config/bufferline_keymaps.lua`.
  - Add key mappings for `multicursor` from `lua/config/multicursor_keymaps.lua`.
  - Add key mappings for `theming` from `lua/config/theming_keymaps.lua`.

* **README.md**
  - Add a detailed description of all features.
  - Include a reference to `KEYS.md` for key mappings.

