### PR TITLE
patch

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,5 @@
 require("config.lazy") -- Lazy.nvim setup
 require("core.settings") -- Load basic settings
 require("core.autocmds")
+require("core.misc")
+require("core.keymaps_cheat")

--- a/lua/config/git_keymaps.lua
+++ b/lua/config/git_keymaps.lua
@@ -1,0 +1,35 @@
+local M = {}
+
+function M.setup()
+  local gs = package.loaded.gitsigns
+  local map = vim.keymap.set
+
+  -- GitSigns Keymaps
+  map("n", "]c", function()
+    if vim.wo.diff then return "]c" end
+    vim.schedule(function() gs.next_hunk() end)
+    return "<Ignore>"
+  end, { expr = true, desc = "Next Git hunk" })
+
+  map("n", "[c", function()
+    if vim.wo.diff then return "[c" end
+    vim.schedule(function() gs.prev_hunk() end)
+    return "<Ignore>"
+  end, { expr = true, desc = "Prev Git hunk" })
+
+  map("n", "<leader>hs", gs.stage_hunk, { desc = "Stage hunk" })
+  map("n", "<leader>hr", gs.reset_hunk, { desc = "Reset hunk" })
+  map("v", "<leader>hs", function() gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") }) end)
+  map("v", "<leader>hr", function() gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") }) end)
+  map("n", "<leader>hS", gs.stage_buffer, { desc = "Stage buffer" })
+  map("n", "<leader>hu", gs.undo_stage_hunk, { desc = "Undo stage" })
+  map("n", "<leader>hR", gs.reset_buffer, { desc = "Reset buffer" })
+  map("n", "<leader>hp", gs.preview_hunk, { desc = "Preview hunk" })
+  map("n", "<leader>hb", function() gs.blame_line({ full = true }) end, { desc = "Blame line" })
+  map("n", "<leader>hd", gs.diffthis, { desc = "Diff against index" })
+
+  -- Git Blame Keymap
+  map("n", "<leader>gb", "<cmd>GitBlameToggle<cr>", { desc = "Toggle Git blame" })
+end
+
+return M

--- a/lua/core/keymaps_cheat.lua
+++ b/lua/core/keymaps_cheat.lua
@@ -1,0 +1,124 @@
+local M = {}
+
+M.keymaps = {
+	-- File Operations
+	File = {
+		["<leader>w"] = "Save file",
+		["<leader>q"] = "Exit file",
+		["<leader>wq"] = "Save and Exit file",
+	},
+
+	-- Buffer Management
+	Buffer = {
+		["<leader>bp"] = "Toggle pin",
+		["<leader>bP"] = "Delete non-pinned buffers",
+		["<leader>bo"] = "Delete other buffers",
+		["<leader>br"] = "Delete buffers to the right",
+		["<leader>bl"] = "Delete buffers to the left",
+		["<leader>bd"] = "Delete buffer",
+	},
+
+	-- Tab Navigation
+	Tabs = {
+		["<Tab>"] = "Next tab",
+		["<S-Tab>"] = "Previous tab",
+	},
+
+	-- Git Integration
+	Git = {
+		["<leader>gc"] = "Git Commits",
+		["<leader>gs"] = "Git Status",
+		["<leader>hs"] = "Stage hunk",
+		["<leader>hr"] = "Reset hunk",
+		["<leader>hS"] = "Stage buffer",
+		["<leader>hu"] = "Undo stage",
+		["<leader>hR"] = "Reset buffer",
+		["<leader>hp"] = "Preview hunk",
+		["<leader>hb"] = "Blame line",
+		["<leader>hd"] = "Diff against index",
+		["<leader>gb"] = "Toggle Git Blame",
+	},
+
+	-- Code Navigation (LSP)
+	LSP = {
+		["gd"] = "Goto Definition",
+		["gr"] = "Find References",
+		["K"] = "Hover Docs",
+		["<leader>rn"] = "Rename Symbol",
+		["<leader>ca"] = "Code Actions",
+	},
+
+	-- Telescope (Search)
+	Search = {
+		["<leader>ff"] = "Find Files",
+		["<leader>fg"] = "Live Grep",
+		["<leader>fb"] = "Find Buffers",
+		["<leader>fh"] = "Help Tags",
+		["<leader>fr"] = "Recent Files",
+		["<C-e>"] = "File Browser",
+	},
+
+	-- UI & Miscellaneous
+	UI = {
+		["<leader>tt"] = "Cycle Themes",
+		["<leader>th"] = "Preview Themes",
+		["<leader>d"] = "Open Dashboard",
+		["<leader>nl"] = "Noice Last Message",
+		["<leader>nh"] = "Noice History",
+		["<leader>na"] = "Noice All Messages",
+		["<leader>nd"] = "Dismiss Noice Notifications",
+	},
+
+	-- Terminal
+	Terminal = {
+		["<C-t>"] = "Toggle Terminal",
+	},
+
+	-- Multi-cursor
+	MultiCursor = {
+		["<leader>n"] = "Match add cursor forward",
+		["<leader>s"] = "Match skip cursor forward",
+		["<leader>N"] = "Match add cursor backward",
+		["<leader>S"] = "Match skip cursor backward",
+		["<leader>A"] = "Add cursors for all matches",
+		["<left>"] = "Next cursor",
+		["<right>"] = "Previous cursor",
+		["<leader>x"] = "Delete current cursor",
+		["<C-q>"] = "Toggle cursors",
+	},
+}
+
+-- Function to display keymaps in a floating window
+function M.show()
+	local buf = vim.api.nvim_create_buf(false, true)
+	local lines = {}
+
+	for section, mappings in pairs(M.keymaps) do
+		table.insert(lines, "### " .. section .. " ###")
+		for k, v in pairs(mappings) do
+			table.insert(lines, string.format("%-10s -> %s", k, v))
+		end
+		table.insert(lines, "") -- Add space between sections
+	end
+
+	vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+
+	local width = math.max(40, vim.api.nvim_win_get_width(0) - 20)
+	local height = math.min(#lines + 2, vim.api.nvim_win_get_height(0) - 5)
+
+	local opts = {
+		relative = "editor",
+		width = width,
+		height = height,
+		col = math.floor((vim.api.nvim_win_get_width(0) - width) / 2),
+		row = math.floor((vim.api.nvim_win_get_height(0) - height) / 2),
+		anchor = "NW",
+		style = "minimal",
+		border = "rounded",
+	}
+
+	local win = vim.api.nvim_open_win(buf, true, opts)
+	vim.api.nvim_buf_set_keymap(buf, "n", "q", "<Cmd>close<CR>", { noremap = true, silent = true })
+end
+
+return M

--- a/lua/core/misc.lua
+++ b/lua/core/misc.lua
@@ -1,0 +1,15 @@
+local set = vim.keymap.set
+
+-- save
+set("n", "<leader>w", "<Cmd>w<CR>", { desc = "Save file" })
+
+-- quit
+set("n", "<leader>q", "<Cmd>q<CR>", { desc = "Exit file" })
+
+-- save and exit
+set("n", "<leader>wq", "<Cmd>wq<CR>", { desc = "Save and Exit file" })
+
+-- show cheat sheet
+set("n", "<leader>km", function()
+	require("core.keymaps_cheat").show()
+end, { desc = "Show Keymaps Cheat Sheet" })

--- a/lua/plugins/chad.lua
+++ b/lua/plugins/chad.lua
@@ -1,4 +1,0 @@
-return {
-	"NvChad/nvcommunity",
-	{ import = "nvcommunity.editor.autosave" },
-}

--- a/lua/plugins/git.lua
+++ b/lua/plugins/git.lua
@@ -13,62 +13,17 @@ return {
 					untracked = { text = "┆" },
 				},
 				on_attach = function(bufnr)
-					local gs = package.loaded.gitsigns
-					local map = function(mode, l, r, opts)
-						opts = opts or {}
-						opts.buffer = bufnr
-						vim.keymap.set(mode, l, r, opts)
-					end
-
-					-- Navigation
-					map("n", "]c", function()
-						if vim.wo.diff then
-							return "]c"
-						end
-						vim.schedule(function()
-							gs.next_hunk()
-						end)
-						return "<Ignore>"
-					end, { expr = true, desc = "Next Git hunk" })
-
-					map("n", "[c", function()
-						if vim.wo.diff then
-							return "[c"
-						end
-						vim.schedule(function()
-							gs.prev_hunk()
-						end)
-						return "<Ignore>"
-					end, { expr = true, desc = "Prev Git hunk" })
-
-					-- Actions
-					map("n", "<leader>hs", gs.stage_hunk, { desc = "Stage hunk" })
-					map("n", "<leader>hr", gs.reset_hunk, { desc = "Reset hunk" })
-					map("v", "<leader>hs", function()
-						gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
-					end)
-					map("v", "<leader>hr", function()
-						gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
-					end)
-					map("n", "<leader>hS", gs.stage_buffer, { desc = "Stage buffer" })
-					map("n", "<leader>hu", gs.undo_stage_hunk, { desc = "Undo stage" })
-					map("n", "<leader>hR", gs.reset_buffer, { desc = "Reset buffer" })
-					map("n", "<leader>hp", gs.preview_hunk, { desc = "Preview hunk" })
-					map("n", "<leader>hb", function()
-						gs.blame_line({ full = true })
-					end, { desc = "Blame line" })
-					map("n", "<leader>hd", gs.diffthis, { desc = "Diff against index" })
+					require("config.git_keymaps").setup()
 				end,
 			})
 		end,
 	},
-	--git blame
 	{
 		"f-person/git-blame.nvim",
 		event = "BufReadPre",
 		config = function()
 			vim.g.gitblame_enabled = 0 -- Disable by default
-			vim.keymap.set("n", "<leader>gb", "<cmd>GitBlameToggle<cr>", { desc = "Toggle Git blame" })
+			require("config.git_keymaps").setup()
 		end,
 	},
 }


### PR DESCRIPTION
This pull request introduces several new keymaps and refactors existing ones to improve code organization and functionality. The most important changes include adding new keymaps for Git operations, creating a cheat sheet for keymaps, and refactoring the Git keymaps setup into a separate module.

Keymap additions and improvements:

* [`lua/config/git_keymaps.lua`](diffhunk://#diff-3b1024bdb41ea9e8737cecd2514481d22e94d89c5112a408a322f396a9491ea5R1-R35): Added new keymaps for Git operations, including navigation between hunks, staging and resetting hunks, previewing hunks, and toggling Git blame.
* [`lua/core/keymaps_cheat.lua`](diffhunk://#diff-48d28dc9b6ca5648d70073e0a9c5e83b67275be806e29bc098b8ab3ad5525d55R1-R124): Created a cheat sheet for keymaps, categorized by functionality such as file operations, buffer management, tab navigation, Git integration, code navigation, search, UI, terminal, and multi-cursor.

Refactoring:

* [`lua/core/misc.lua`](diffhunk://#diff-234b6f6fd470c3727dad5cbbf637dac55b7103822473cd461fc298578df881a2R1-R15): Added keymaps for saving, quitting, and showing the keymaps cheat sheet, improving the organization of miscellaneous keymaps.
* [`lua/plugins/git.lua`](diffhunk://#diff-846c5748683a018a598cf1cc7d15ed25fee8887ff8b91672a3211d8b2986eff7L16-R26): Refactored the Git keymaps setup to use the new `config.git_keymaps` module, improving code maintainability and readability.

Removal of unused code:

* [`lua/plugins/chad.lua`](diffhunk://#diff-61c74154000787506cc6297777fdca1c43f1252844db5562717a43dfb56cec13L1-L4): Removed the unused `NvChad/nvcommunity` plugin configuration.