### PR TITLE
load gitsigns properly

### DIFF
--- a/lua/config/git_keymaps.lua
+++ b/lua/config/git_keymaps.lua
@@ -1,35 +1,50 @@
 local M = {}
 
 function M.setup()
-  local gs = package.loaded.gitsigns
-  local map = vim.keymap.set
+	-- Safely require gitsigns
+	local gs = require("gitsigns")
+	local map = vim.keymap.set
 
-  -- GitSigns Keymaps
-  map("n", "]c", function()
-    if vim.wo.diff then return "]c" end
-    vim.schedule(function() gs.next_hunk() end)
-    return "<Ignore>"
-  end, { expr = true, desc = "Next Git hunk" })
+	-- GitSigns Keymaps
+	map("n", "]c", function()
+		if vim.wo.diff then
+			return "]c"
+		end
+		vim.schedule(function()
+			gs.next_hunk()
+		end)
+		return "<Ignore>"
+	end, { expr = true, desc = "Next Git hunk" })
 
-  map("n", "[c", function()
-    if vim.wo.diff then return "[c" end
-    vim.schedule(function() gs.prev_hunk() end)
-    return "<Ignore>"
-  end, { expr = true, desc = "Prev Git hunk" })
+	map("n", "[c", function()
+		if vim.wo.diff then
+			return "[c"
+		end
+		vim.schedule(function()
+			gs.prev_hunk()
+		end)
+		return "<Ignore>"
+	end, { expr = true, desc = "Prev Git hunk" })
 
-  map("n", "<leader>hs", gs.stage_hunk, { desc = "Stage hunk" })
-  map("n", "<leader>hr", gs.reset_hunk, { desc = "Reset hunk" })
-  map("v", "<leader>hs", function() gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") }) end)
-  map("v", "<leader>hr", function() gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") }) end)
-  map("n", "<leader>hS", gs.stage_buffer, { desc = "Stage buffer" })
-  map("n", "<leader>hu", gs.undo_stage_hunk, { desc = "Undo stage" })
-  map("n", "<leader>hR", gs.reset_buffer, { desc = "Reset buffer" })
-  map("n", "<leader>hp", gs.preview_hunk, { desc = "Preview hunk" })
-  map("n", "<leader>hb", function() gs.blame_line({ full = true }) end, { desc = "Blame line" })
-  map("n", "<leader>hd", gs.diffthis, { desc = "Diff against index" })
+	map("n", "<leader>hs", gs.stage_hunk, { desc = "Stage hunk" })
+	map("n", "<leader>hr", gs.reset_hunk, { desc = "Reset hunk" })
+	map("v", "<leader>hs", function()
+		gs.stage_hunk({ vim.fn.line("."), vim.fn.line("v") })
+	end)
+	map("v", "<leader>hr", function()
+		gs.reset_hunk({ vim.fn.line("."), vim.fn.line("v") })
+	end)
+	map("n", "<leader>hS", gs.stage_buffer, { desc = "Stage buffer" })
+	map("n", "<leader>hu", gs.undo_stage_hunk, { desc = "Undo stage" })
+	map("n", "<leader>hR", gs.reset_buffer, { desc = "Reset buffer" })
+	map("n", "<leader>hp", gs.preview_hunk, { desc = "Preview hunk" })
+	map("n", "<leader>hb", function()
+		gs.blame_line({ full = true })
+	end, { desc = "Blame line" })
+	map("n", "<leader>hd", gs.diffthis, { desc = "Diff against index" })
 
-  -- Git Blame Keymap
-  map("n", "<leader>gb", "<cmd>GitBlameToggle<cr>", { desc = "Toggle Git blame" })
+	-- Git Blame Keymap
+	map("n", "<leader>gb", "<cmd>GitBlameToggle<cr>", { desc = "Toggle Git blame" })
 end
 
 return M

--- a/lua/plugins/git.lua
+++ b/lua/plugins/git.lua
@@ -1,6 +1,7 @@
 return {
 	{
 		"lewis6991/gitsigns.nvim",
+		lazy = true,
 		event = "BufReadPre",
 		config = function()
 			require("gitsigns").setup({

--- a/lua/plugins/multicursor.lua
+++ b/lua/plugins/multicursor.lua
@@ -1,6 +1,7 @@
 return {
 	{
 		"jake-stewart/multicursor.nvim",
+		lazy = true,
 		branch = "1.0",
 		config = function()
 			require("config.multicursor").setup()

--- a/lua/plugins/terminal.lua
+++ b/lua/plugins/terminal.lua
@@ -1,6 +1,7 @@
 return {
 	{
 		"akinsho/toggleterm.nvim",
+		lazy = true,
 		config = function()
 			require("toggleterm").setup({
 				open_mapping = [[<c-t>]],


### PR DESCRIPTION
This pull request includes several changes to Lua configuration files, focusing on improving the code structure and adding lazy loading for specific plugins. The most important changes are grouped by theme below:

### Code Structure Improvements:

* [`lua/config/git_keymaps.lua`](diffhunk://#diff-3b1024bdb41ea9e8737cecd2514481d22e94d89c5112a408a322f396a9491ea5L4-R43): Improved code readability by adding comments, using consistent indentation, and refactoring keymap function definitions for clarity.

### Plugin Configuration Enhancements:

* [`lua/plugins/git.lua`](diffhunk://#diff-846c5748683a018a598cf1cc7d15ed25fee8887ff8b91672a3211d8b2986eff7R4): Enabled lazy loading for the `gitsigns.nvim` plugin to optimize startup performance.
* [`lua/plugins/multicursor.lua`](diffhunk://#diff-78a77753d0fdf179e5f05beb6760d5313c9657b08737ed7b43582dbb577f39fbR4): Enabled lazy loading for the `multicursor.nvim` plugin to improve efficiency.
* [`lua/plugins/terminal.lua`](diffhunk://#diff-c2cfde0ae4704f222abdc7fd376f4c9c9aed0ecad8f5f8577024d839c04ff40eR4): Enabled lazy loading for the `toggleterm.nvim` plugin to enhance performance.