### PR TITLE
Update

### DIFF
--- a/lua/config/undo_keymaps.lua
+++ b/lua/config/undo_keymaps.lua
@@ -1,0 +1,14 @@
+local M = {}
+
+function M.setup()
+	-- Basic undo/redo
+	vim.keymap.set("n", "u", "<cmd>undo<CR>", { desc = "Undo" })
+	vim.keymap.set("n", "<C-r>", "<cmd>redo<CR>", { desc = "Redo" })
+
+	-- Enhanced navigation
+	vim.keymap.set("n", "<leader>uu", "<cmd>UndotreeToggle<CR>", { desc = "Toggle Undo Tree" })
+	vim.keymap.set("n", "<leader>uf", "<cmd>UndotreeFocus<CR>", { desc = "Focus Undo Tree" })
+	vim.keymap.set("n", "<leader>uh", "<cmd>UndotreeHide<CR>", { desc = "Hide Undo Tree" })
+end
+
+return M

--- a/lua/core/settings.lua
+++ b/lua/core/settings.lua
@@ -1,4 +1,3 @@
--- lua/core/settings.lua
 local opt = vim.opt
 local g = vim.g
 
@@ -27,3 +26,22 @@ opt.splitbelow = true -- Open horizontal splits below
 opt.lazyredraw = true -- Only redraw when needed
 opt.updatetime = 300 -- Faster completion
 opt.timeoutlen = 500 -- Faster mappings
+
+-- undo
+
+opt.undolevels = 10000 -- Max undo levels
+opt.undoreload = 10000 -- Max lines to save for undo
+
+if vim.fn.has("persistent_undo") == 1 then
+	local target_path = vim.fn.expand("~/.undodir")
+
+	-- Use double slash for versioned undo files
+	target_path = target_path .. "//"
+
+	if vim.fn.isdirectory(target_path) == 0 then
+		vim.fn.mkdir(target_path, "p", 0700)
+	end
+
+	vim.o.undodir = target_path
+	vim.o.undofile = true
+end

--- a/lua/plugins/git.lua
+++ b/lua/plugins/git.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		"lewis6991/gitsigns.nvim",
-		lazy = true,
 		event = "BufReadPre",
 		config = function()
 			require("gitsigns").setup({

--- a/lua/plugins/terminal.lua
+++ b/lua/plugins/terminal.lua
@@ -1,7 +1,6 @@
 return {
 	{
 		"akinsho/toggleterm.nvim",
-		lazy = true,
 		config = function()
 			require("toggleterm").setup({
 				open_mapping = [[<c-t>]],

--- a/lua/plugins/undo.lua
+++ b/lua/plugins/undo.lua
@@ -1,0 +1,19 @@
+return {
+	{
+		"mbbill/undotree",
+		keys = {
+			{ "<leader>uu", "<cmd>UndotreeToggle<CR>", desc = "Toggle Undo Tree" },
+			{ "<leader>uf", "<cmd>UndotreeFocus<CR>", desc = "Focus Undo Tree" },
+		},
+		config = function()
+			vim.g.undotree_SetFocusWhenToggle = 1
+			vim.g.undotree_WindowLayout = 3
+			vim.g.undotree_ShortIndicators = 1
+			vim.g.undotree_DiffAutoOpen = 0
+			vim.g.undotree_DiffpanelHeight = 10
+
+			-- Load keymaps after plugin setup
+			require("config.undo_keymaps").setup()
+		end,
+	},
+}


### PR DESCRIPTION
This pull request includes several changes to enhance the undo functionality in the Neovim configuration, as well as some adjustments to the plugin settings. The most important changes include setting up keymaps for undo operations, configuring persistent undo settings, and adding the `undotree` plugin.

Enhancements to undo functionality:

* [`lua/config/undo_keymaps.lua`](diffhunk://#diff-43bc65c913f0b25cbda873e0c49362cf28ba46d8e60bfc755b4aae4c3da8abefR1-R14): Added a new module to set up keymaps for basic undo/redo operations and enhanced navigation with the undo tree.
* [`lua/core/settings.lua`](diffhunk://#diff-6c87ad0337486756e539ccc4fa9aec02cd9fa3057a8947444a9ea658299bfcc3R29-R47): Configured persistent undo settings, including setting maximum undo levels and creating the undo directory if it doesn't exist.

Plugin adjustments:

* [`lua/plugins/undo.lua`](diffhunk://#diff-2b64fe758c28db876161a091b7022405c4c811e88fca214e16dca56cf3714982R1-R19): Added the `undotree` plugin with key bindings and configuration settings.
* [`lua/plugins/git.lua`](diffhunk://#diff-846c5748683a018a598cf1cc7d15ed25fee8887ff8b91672a3211d8b2986eff7L4): Changed the `gitsigns.nvim` plugin to load on the `BufReadPre` event instead of being lazy-loaded.
* [`lua/plugins/terminal.lua`](diffhunk://#diff-c2cfde0ae4704f222abdc7fd376f4c9c9aed0ecad8f5f8577024d839c04ff40eL4): Changed the `toggleterm.nvim` plugin to load immediately instead of being lazy-loaded.